### PR TITLE
5.6 Ключи

### DIFF
--- a/lib/constants/app_strings.dart
+++ b/lib/constants/app_strings.dart
@@ -25,9 +25,9 @@ class AppStrings {
   static const String sightCardToBeVisitedText = 'Запланировано на';
   static const String placeholderNoItemsTitleText = 'Пусто';
   static const String placeholderNoToVisitSightsText =
-      'Отмечайте понравившиеся места и они появятся здесь.';
+      'Отмечайте понравившиеся\nместа и они появятся здесь.';
   static const String placeholderNoVisitedSightsText =
-      'Завершите маршрут, чтобы место попало сюда.';
+      'Завершите маршрут,\nчтобы место попало сюда.';
 
   /// Тексты окна Избранное
   static const String favoriteScreenAppBarTitle = 'Избранное';

--- a/lib/domain/location_point.dart
+++ b/lib/domain/location_point.dart
@@ -1,7 +1,12 @@
+import 'package:equatable/equatable.dart';
+
 /// Модель координаты с широтой [lat] и долготой [lon]
-class LocationPoint {
+class LocationPoint extends Equatable {
   final double lat;
   final double lon;
+
+  @override
+  List<Object?> get props => [lat, lon];
 
   const LocationPoint({
     required this.lat,

--- a/lib/domain/sight.dart
+++ b/lib/domain/sight.dart
@@ -1,3 +1,4 @@
+import 'package:equatable/equatable.dart';
 import 'package:places/domain/location_point.dart';
 import 'package:places/domain/sight_category.dart';
 
@@ -7,12 +8,15 @@ import 'package:places/domain/sight_category.dart';
 /// [url] - путь на картинку достопримечательности в интернете
 /// [details] - полное описание достопримечательности
 /// [category] - категория достопримечательности
-class Sight {
+class Sight extends Equatable{
   final String name;
   final LocationPoint point;
   final String? url;
   final String details;
   final SightCategory category;
+
+  @override
+  List<Object?> get props => [name, point, url, details, category];
 
   const Sight({
     required this.name,

--- a/lib/ui/screen/visiting_screen/visiting_screen.dart
+++ b/lib/ui/screen/visiting_screen/visiting_screen.dart
@@ -3,6 +3,7 @@ import 'package:places/constants/app_assets.dart';
 import 'package:places/constants/app_constants.dart';
 import 'package:places/constants/app_strings.dart';
 import 'package:places/constants/app_typography.dart';
+import 'package:places/domain/sight.dart';
 import 'package:places/mocks.dart';
 import 'package:places/ui/screen/custom_tab_bar.dart';
 import 'package:places/ui/screen/no_items_placeholder.dart';
@@ -20,11 +21,15 @@ class VisitingScreen extends StatefulWidget {
 
 class _VisitingScreenState extends State<VisitingScreen>
     with TickerProviderStateMixin {
-  late TabController _tabController;
+  late final TabController _tabController;
+  final List<Sight> _toVisitSights = [];
+  final List<Sight> _visitedSights = [];
 
   @override
   void initState() {
     super.initState();
+    _toVisitSights.addAll(sightsMock.take(3));
+    _visitedSights.addAll(sightsMock.reversed.take(3));
     _tabController = TabController(length: 2, vsync: this);
     _tabController.addListener(() => setState(() {}));
   }
@@ -65,12 +70,16 @@ class _VisitingScreenState extends State<VisitingScreen>
           controller: _tabController,
           children: [
             SightList(
-              sightCards: sightsMock
+              sightCards: _toVisitSights
                   .map((sight) => SightToVisitCard(
+                        key: ObjectKey(sight),
                         sight: sight,
                         dateOfVisit: DateTime.now(),
                         onPlanPressed: () {},
-                        onDeletePressed: () {},
+                        onDeletePressed: () => _deleteSight(
+                          sightToRemove: sight,
+                          source: _toVisitSights,
+                        ),
                         onCardTapped: () {},
                       ))
                   .toList(),
@@ -81,12 +90,16 @@ class _VisitingScreenState extends State<VisitingScreen>
               ),
             ),
             SightList(
-              sightCards: sightsMock
+              sightCards: _visitedSights
                   .map((sight) => SightVisitedCard(
+                        key: ObjectKey(sight),
                         sight: sight,
                         dateOfVisit: DateTime.now(),
                         onSharePressed: () {},
-                        onDeletePressed: () {},
+                        onDeletePressed: () => _deleteSight(
+                          sightToRemove: sight,
+                          source: _visitedSights,
+                        ),
                         onCardTapped: () {},
                       ))
                   .toList(),
@@ -100,5 +113,14 @@ class _VisitingScreenState extends State<VisitingScreen>
         ),
       ),
     );
+  }
+
+  void _deleteSight({
+    required Sight sightToRemove,
+    required List<Sight> source,
+  }) {
+    setState(() {
+      source.removeWhere((sight) => sight == sightToRemove);
+    });
   }
 }


### PR DESCRIPTION
Для корректного удаления виджета карточки места из дерева (в контексте переиспользования виджета) назначил ему ObjectKey, передав в него сам объект Sight. Поскольку в этом объекте переопределяется метод equals (спасибо пакету Equatable), то на данном наборе мест мы гарантируем уникальность этих объектов.  
Демонстрация удаления

https://user-images.githubusercontent.com/101569759/163606467-18367515-607b-4eae-b99c-63f5c79dd59c.mov

