### PR TITLE
11.2 Streams, StreamBuilder

### DIFF
--- a/lib/ui/screen/place_card/place_view_card.dart
+++ b/lib/ui/screen/place_card/place_view_card.dart
@@ -15,7 +15,7 @@ class PlaceViewCard extends PlaceCard {
           place: place,
           actionButtons: PlaceViewCardActionButtons(
             onFavoritePressed: onFavoritePressed,
-            isPlaceInFavorites: place.isInFavorites,
+            place: place,
           ),
           onCardTapped: onCardTapped,
           key: key,


### PR DESCRIPTION

https://user-images.githubusercontent.com/101569759/168146521-1168ed29-ee18-456b-9a7e-a13d1af4d5ed.mp4

Заметил, что если загрузка из сети происходит быстро, то прогресс индикатор появляется на очень короткое время и возникает эффект дёрганья. Пока в голову приходит следующее для решения этой проблемы: я бы запускал прогресс индикатор только если загрузка из сети длится более N секунд или сразу, если загрузка первая (отсутствуют данные в хранилище локально). Но это окончательно не решит проблему, а лишь сделает ее более редкой, потому что могут быть ситуации, когда условно данные грузятся уже 3 секунды как, запускаем лоадинг индикатор, и через пол секунды данные приходят и все равно этот эффект наблюдается.

Очень интересно, как у вас в компании решают данную проблему? 